### PR TITLE
Remove pathlib dependency.

### DIFF
--- a/format.py
+++ b/format.py
@@ -4,7 +4,6 @@ import subprocess
 import re
 import os
 import tempfile
-import pathlib
 import platform
 
 SETTINGS_PATH = 'Default.sublime-settings'
@@ -187,7 +186,7 @@ class FormatCommand(sublime_plugin.TextCommand):
     if bscExe == None:
       return
 
-    extension = pathlib.Path(filename).suffix
+    _, extension = os.path.splitext(filename)
     formattedResult = formatUsingValidBscPath(
       code,
       bscExe,


### PR DESCRIPTION
`pathlib` is not available in python 2.7; `format.py` will crash in that situation.
The easiest solution is to just remove the dependency on`pathlib` and use `os.path.splitext` which seems to be supported by both python 2 and python 3.