### PR TITLE
Fix tilde character interpreted as null in syntax

### DIFF
--- a/ReScript.sublime-syntax
+++ b/ReScript.sublime-syntax
@@ -36,7 +36,7 @@ contexts:
           pop: true
 
   punctuations:
-    - match: ~
+    - match: \~
       scope: punctuation.definition.keyword
     - match: ;
       scope: punctuation.terminator


### PR DESCRIPTION
Sublime (Linux, build 4090) threw an error for me when loading `.res` files

```
error parsing lexer: Packages/User/rescript-sublime/ReScript.sublime-syntax: invalid type for match at line 39 column 14
generating syntax summary
error: Error loading syntax file "Packages/User/rescript-sublime/ReScript.sublime-syntax": invalid type for match at line 39 column 14
```

AFAIK, tilde characters in yaml mean `null` [1], so they either need to be wrapped in quotes or escaped. Don't know if the yaml parser in Sublime Text 4 has been updated so that this now becomes an issue.


[1] https://yaml.org/spec/1.2/spec.html#id2805071